### PR TITLE
pr-source-check: use ubuntu-latest

### DIFF
--- a/.github/workflows/pr-source-check.yaml
+++ b/.github/workflows/pr-source-check.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-source-check:
     name: PR source must be develop
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Ensure PR source is develop
         run: |


### PR DESCRIPTION
Public repo has no self-hosted runner access; the check would never run otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)